### PR TITLE
Upgrade to 2.2.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = {
             edit: 'Bewerk',
             sort: 'Sorteer',
             cancel: 'Annuleer',
+            clear_input_value: 'Veld wissen',
             undo: 'Ongedaan maken',
             refresh: 'Ververs',
             add: 'Voeg toe',

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ module.exports = {
             remove_filter: 'Verwijder dit filter',
             back: 'Ga terug',
             bulk_actions: '%{smart_count} geselecteerd',
+            export: 'Exporteer',
         },
         boolean: {
             true: 'Ja',

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ module.exports = {
             dashboard: 'Dashboard',
             not_found: 'Niet gevonden',
             loading: 'Aan het laden',
+            error: 'Er is iets misgegaan',
         },
         input: {
           file: {
@@ -67,6 +68,8 @@ module.exports = {
           invalid_form: 'Het formulier is ongeldig. Controleer a.u.b. de foutmeldingen',
           delete_title: '%{name} #%{id} verwijderen',
           delete_content: 'Weet u zeker dat u dit item wilt verwijderen?',
+          error:
+               'Er is een clientfout opgetreden en uw aanvraag kon niet worden voltooid.',
           bulk_delete_title:
               'Verwijder %{name} |||| Verwijder %{smart_count} %{name} items',
           bulk_delete_content:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ra-language-dutch",
-  "version": "2.0.1",
+  "version": "2.2.0",
   "description": "Dutch translations for react-admin. A frontend Framework for building admin applications running in the browser on top of REST/GraphQL services, using ES6, React and Material Design",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Today react-admin 2.2.0 was [released](https://github.com/marmelab/react-admin/blob/master/CHANGELOG.md#v220). A quick dependency check showed that these translations were outdated; I went out and added all the missing translations!